### PR TITLE
Python3 adaptation of pyrqa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,173 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# PyPI configuration file
+.pypirc
+
+**/*.bak

--- a/README.md
+++ b/README.md
@@ -101,8 +101,11 @@ or create a new computation object, e.g.,::
 Environment
 -----------
 
-PyRQA has been tested under Python 2.7 on Mac OS X (Mavericks, Yosemite) as well as openSUSE (12.2, 13.2).
+This library has been tested under Python 3.10 on Ubuntu 22.04 x86_64 with kernel version 5.15.0-126-generic. 
 
+Benchmark
+-----------
+It takes approximately 120 seconds to run all tests on single Nvidia RTX3090 with driver verion 555.42.06.
 
 Contribution
 ------------

--- a/pyrqa/__main__.py
+++ b/pyrqa/__main__.py
@@ -11,11 +11,11 @@ import argparse
 import numpy as np
 import os
 
-from computation import RecurrencePlotComputation, RQAComputation
-from file_reader import FileReader
-from image_generator import ImageGenerator
-from neighbourhood import FixedRadius, RadiusCorridor, FAN
-from settings import Settings
+from .computation import RecurrencePlotComputation, RQAComputation
+from .file_reader import FileReader
+from .image_generator import ImageGenerator
+from .neighbourhood import FixedRadius, RadiusCorridor, FAN
+from .settings import Settings
 
 def parse_arguments():
     """
@@ -255,5 +255,5 @@ if __name__ == "__main__":
                              output_path,
                              arguments)
     else:
-        print result
-        print result.runtimes
+        print(result)
+        print((result.runtimes))

--- a/pyrqa/abstract_classes.py
+++ b/pyrqa/abstract_classes.py
@@ -21,35 +21,32 @@ class abstractclassmethod(classmethod):
         super(abstractclassmethod, self).__init__(cllble)
 
 
-class AbstractSettings(object):
+class AbstractSettings(object, metaclass=abc.ABCMeta):
     """
     Abstract settings.
 
     :ivar settings: Recurrence analysis settings.
     """
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, settings):
         self.settings = settings
 
 
-class AbstractRuntimes(object):
+class AbstractRuntimes(object, metaclass=abc.ABCMeta):
     """
     Abstract runtimes
 
     :ivar runtimes: Computing runtimes.
     """
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, runtimes):
         self.runtimes = runtimes
 
 
-class AbstractRunnable(object):
+class AbstractRunnable(object, metaclass=abc.ABCMeta):
     """
     Abstract runnable.
     """
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
     def run(self):
@@ -65,13 +62,12 @@ class AbstractRunnable(object):
         pass
 
 
-class AbstractVerbose(object):
+class AbstractVerbose(object, metaclass=abc.ABCMeta):
     """
     Abstract verbose.
 
     :ivar verbose: Boolean value indicating the verbosity of print outs.
     """
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, verbose):
         self.verbose = verbose
@@ -79,14 +75,13 @@ class AbstractVerbose(object):
     def print_out(self, string):
         """ Print string if verbose is true. """
         if self.verbose:
-            print string
+            print(string)
 
 
-class AbstractMetric(object):
+class AbstractMetric(object, metaclass=abc.ABCMeta):
     """
     Abstract metric.
     """
-    __metaclass__ = abc.ABCMeta
     name = 'metric'
 
     @classmethod
@@ -126,11 +121,10 @@ class AbstractMetric(object):
         pass
 
 
-class AbstractNeighbourhood(object):
+class AbstractNeighbourhood(object, metaclass=abc.ABCMeta):
     """
     Abstract neighbourhood.
     """
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
     def contains(self, sample):

--- a/pyrqa/file_reader.py
+++ b/pyrqa/file_reader.py
@@ -41,10 +41,10 @@ class FileReader(object):
                     result.append(np.float32(splitted_line[column]))
                 else:
                     line_count += 1
-                    print "No element of index %d in line '%s'." % (column, line)
+                    print(("No element of index %d in line '%s'." % (column, line)))
 
             if line_count:
-                print "%d lines could not be processed." % line_count
+                print(("%d lines could not be processed." % line_count))
 
             return np.array(result)
 

--- a/pyrqa/opencl.py
+++ b/pyrqa/opencl.py
@@ -12,12 +12,12 @@ import numpy as np
 import os
 import pyopencl as cl
 
-from abstract_classes import AbstractVerbose
-from exceptions import NoOpenCLPlatformDetectedException, \
+from .abstract_classes import AbstractVerbose
+from .exceptions import NoOpenCLPlatformDetectedException, \
     NoOpenCLDeviceDetectedException, \
     OpenCLPlatformIndexOutOfBoundsException, \
     OpenCLDeviceIndexOutOfBoundsException
-from file_reader import FileReader
+from .file_reader import FileReader
 
 
 class OpenCL(AbstractVerbose):
@@ -123,11 +123,11 @@ class OpenCL(AbstractVerbose):
         :rtype: String.
         """
         program_source = ''
-        for kernel_file_name, kernel_source in self.locate_kernels().iteritems():
+        for kernel_file_name, kernel_source in list(self.locate_kernels().items()):
             if kernel_source:
                 program_source += kernel_source
             else:
-                print "Kernel with file name '%s' could not be found!" % kernel_file_name
+                print(("Kernel with file name '%s' could not be found!" % kernel_file_name))
 
         return program_source
 
@@ -191,7 +191,7 @@ class OpenCL(AbstractVerbose):
             for platform_idx in np.arange(len(platforms)):
                 platform_strings.append("[%d] %s" % (platform_idx, platforms[platform_idx]))
 
-            platform_select = int(raw_input("\nAvailable platform(s):\n%s\n\nChoose platform, e.g., '0': " % "\n".join(platform_strings)))
+            platform_select = int(eval(input("\nAvailable platform(s):\n%s\n\nChoose platform, e.g., '0': " % "\n".join(platform_strings))))
 
             if platform_select not in np.arange(len(platforms)):
                 raise OpenCLPlatformIndexOutOfBoundsException("Platform index '%d' is out of bounds." % platform_select)
@@ -204,7 +204,7 @@ class OpenCL(AbstractVerbose):
                 for device_idx in np.arange(len(devices)):
                     device_strings.append("[%d] %s" % (device_idx, devices[device_idx]))
 
-                device_select = raw_input("\nAvailable device(s):\n%s\n\nChoose device(s), comma-separated, e.g., '0,1': " % "\n".join(device_strings))
+                device_select = eval(input("\nAvailable device(s):\n%s\n\nChoose device(s), comma-separated, e.g., '0,1': " % "\n".join(device_strings)))
 
                 device_indices = [int(x) for x in device_select.split(',')]
 
@@ -261,7 +261,7 @@ class OpenCL(AbstractVerbose):
         try:
             platforms = cl.get_platforms()
         except cl.RuntimeError as error:
-            print "Could not find any platform: ", error
+            print(("Could not find any platform: ", error))
 
         if platform_id is not None:
             if platform_id in np.arange(len(platforms)):

--- a/pyrqa/recurrence_analysis.py
+++ b/pyrqa/recurrence_analysis.py
@@ -9,12 +9,12 @@ Recurrence analysis
 
 import abc
 import math
-import Queue
+import queue
 
 import numpy as np
 
-import processing_order as po
-from abstract_classes import AbstractSettings, \
+from . import processing_order as po
+from .abstract_classes import AbstractSettings, \
     AbstractVerbose
 
 
@@ -187,7 +187,7 @@ class SubMatrices(AbstractSettings):
                     queue_index = 0
 
                 if len(self.sub_matrix_queues) <= queue_index:
-                    self.sub_matrix_queues.append(Queue.Queue())
+                    self.sub_matrix_queues.append(queue.Queue())
 
                 self.sub_matrix_queues[queue_index].put(sub_matrix)
 

--- a/pyrqa/recurrence_plot/fixed_radius/opencl/column_byte.py
+++ b/pyrqa/recurrence_plot/fixed_radius/opencl/column_byte.py
@@ -158,9 +158,9 @@ class ColumnByte(RecurrencePlotSubMatrices, AbstractRunnable):
                 command_queue.finish()
 
                 # Read buffer
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          matrix_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           matrix,
+                                                                          matrix_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))

--- a/pyrqa/recurrence_plot/fixed_radius/opencl/column_byte.py
+++ b/pyrqa/recurrence_plot/fixed_radius/opencl/column_byte.py
@@ -12,7 +12,7 @@ import os
 import pyopencl as cl
 import threading
 
-import Queue
+import queue
 
 from ....abstract_classes import AbstractRunnable
 from ....opencl import OpenCL
@@ -178,7 +178,7 @@ class ColumnByte(RecurrencePlotSubMatrices, AbstractRunnable):
 
                 self.threads_runtimes[device] += runtimes
 
-            except Queue.Empty:
+            except queue.Empty:
                 break
 
     def run_single_device(self):
@@ -206,7 +206,7 @@ class ColumnByte(RecurrencePlotSubMatrices, AbstractRunnable):
         runtimes = Runtimes()
 
         if len(self.opencl.devices) == 0:
-            print 'No device specified!'
+            print('No device specified!')
             return 0
         elif len(self.opencl.devices) == 1:
             self.run_single_device()

--- a/pyrqa/recurrence_plot/fixed_radius/opencl/column_byte.py
+++ b/pyrqa/recurrence_plot/fixed_radius/opencl/column_byte.py
@@ -96,7 +96,7 @@ class ColumnByte(RecurrencePlotSubMatrices, AbstractRunnable):
                                                  cl.mem_flags.READ_ONLY,
                                                  time_series_x.size * time_series_x.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          time_series_x_buffer,
                                                                          time_series_x,
                                                                          device_offset=0,
@@ -109,7 +109,7 @@ class ColumnByte(RecurrencePlotSubMatrices, AbstractRunnable):
                                                  cl.mem_flags.READ_ONLY,
                                                  time_series_y.size * time_series_y.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          time_series_y_buffer,
                                                                          time_series_y,
                                                                          device_offset=0,
@@ -124,7 +124,7 @@ class ColumnByte(RecurrencePlotSubMatrices, AbstractRunnable):
                                           cl.mem_flags.READ_WRITE,
                                           matrix.size * matrix.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          matrix_buffer,
                                                                          matrix,
                                                                          device_offset=0,
@@ -133,7 +133,7 @@ class ColumnByte(RecurrencePlotSubMatrices, AbstractRunnable):
 
                 # matrix = np.zeros(1, dtype=self.data_type)
                 # matrix_buffer = cl.Buffer(context, cl.mem_flags.READ_WRITE, int(self.get_matrix_size(sub_matrix, self.data_type)))
-                # transfer_to_device_events.append( cl.enqueue_write_buffer(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False) )
+                # transfer_to_device_events.append( cl.enqueue_copy(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False) )
 
                 # Create matrix kernel
                 create_matrix_args = [time_series_x_buffer,

--- a/pyrqa/result.py
+++ b/pyrqa/result.py
@@ -9,7 +9,7 @@ Results
 
 import numpy as np
 
-from abstract_classes import AbstractSettings, AbstractRuntimes
+from .abstract_classes import AbstractSettings, AbstractRuntimes
 
 
 class RecurrencePlotResult(AbstractSettings, AbstractRuntimes):

--- a/pyrqa/rqa/fixed_radius/opencl/column_mat_bit_no_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_mat_bit_no_rec.py
@@ -364,51 +364,51 @@ class ColumnMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                 command_queue.finish()
 
                 # Read buffer
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          recurrence_points_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.recurrence_points[recurrence_points_start:recurrence_points_end],
+                                                                          recurrence_points_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           vertical_frequency_distribution,
+                                                                          vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.vertical_length_carryover[vertical_carryover_start:vertical_carryover_end],
+                                                                          vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           white_vertical_frequency_distribution,
+                                                                          white_vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.white_vertical_length_carryover[white_vertical_carryover_start:white_vertical_carryover_end],
+                                                                          white_vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           diagonal_frequency_distribution,
+                                                                          diagonal_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.diagonal_length_carryover[diagonal_carryover_start:diagonal_carryover_end],
+                                                                          diagonal_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))

--- a/pyrqa/rqa/fixed_radius/opencl/column_mat_bit_no_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_mat_bit_no_rec.py
@@ -12,7 +12,7 @@ import os
 import pyopencl as cl
 import threading
 
-import Queue
+import queue
 
 from ....abstract_classes import AbstractRunnable
 from ....opencl import OpenCL
@@ -430,7 +430,7 @@ class ColumnMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
 
                 self.threads_runtimes[device] += runtimes
 
-            except Queue.Empty:
+            except queue.Empty:
                 break
 
     def run_single_device(self):
@@ -459,7 +459,7 @@ class ColumnMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
         runtimes = Runtimes()
 
         if len(self.opencl.devices) == 0:
-            print 'No device specified!'
+            print('No device specified!')
             return 0
         elif len(self.opencl.devices) == 1:
             self.run_single_device()

--- a/pyrqa/rqa/fixed_radius/opencl/column_mat_bit_no_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_mat_bit_no_rec.py
@@ -109,7 +109,7 @@ class ColumnMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                  cl.mem_flags.READ_ONLY,
                                                  time_series_x.size * time_series_x.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          time_series_x_buffer,
                                                                          time_series_x,
                                                                          device_offset=0,
@@ -123,7 +123,7 @@ class ColumnMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                  cl.mem_flags.READ_ONLY,
                                                  time_series_y.size * time_series_y.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          time_series_y_buffer,
                                                                          time_series_y,
                                                                          device_offset=0,
@@ -133,7 +133,7 @@ class ColumnMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                 # Recurrence matrix
                 # matrix = self.get_bit_matrix(sub_matrix, self.data_type)
                 # matrix_buffer = cl.Buffer(context, cl.mem_flags.READ_WRITE, matrix.size * matrix.itemsize)
-                # transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
+                # transfer_to_device_events.append(cl.enqueue_copy(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
 
                 matrix_size, matrix_elements = self.get_bit_matrix_size(sub_matrix, self.data_type)
                 matrix = np.zeros(1, dtype=self.data_type)
@@ -142,7 +142,7 @@ class ColumnMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                           cl.mem_flags.READ_WRITE,
                                           int(matrix_size))
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          matrix_buffer,
                                                                          matrix,
                                                                          device_offset=0,
@@ -158,7 +158,7 @@ class ColumnMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                      cl.mem_flags.READ_WRITE,
                                                      recurrence_points.size * recurrence_points.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          recurrence_points_buffer,
                                                                          recurrence_points,
                                                                          device_offset=0,
@@ -172,7 +172,7 @@ class ColumnMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    vertical_frequency_distribution.size * vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_frequency_distribution_buffer,
                                                                          vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -186,7 +186,7 @@ class ColumnMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                          cl.mem_flags.READ_WRITE,
                                                                          white_vertical_frequency_distribution.size * white_vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_frequency_distribution_buffer,
                                                                          white_vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -200,7 +200,7 @@ class ColumnMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    diagonal_frequency_distribution.size * diagonal_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_frequency_distribution_buffer,
                                                                          diagonal_frequency_distribution,
                                                                          device_offset=0,
@@ -216,7 +216,7 @@ class ColumnMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       vertical_carryover.size * vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_carryover_buffer,
                                                                          vertical_carryover,
                                                                          device_offset=0,
@@ -232,7 +232,7 @@ class ColumnMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                             cl.mem_flags.READ_WRITE,
                                                             white_vertical_carryover.size * white_vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_carryover_buffer,
                                                                          white_vertical_carryover,
                                                                          device_offset=0,
@@ -248,7 +248,7 @@ class ColumnMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       diagonal_carryover.size * diagonal_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_carryover_buffer,
                                                                          diagonal_carryover,
                                                                          device_offset=0,

--- a/pyrqa/rqa/fixed_radius/opencl/column_mat_bit_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_mat_bit_rec.py
@@ -346,51 +346,51 @@ class ColumnMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                 command_queue.finish()
 
                 # Read buffer
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          recurrence_points_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.recurrence_points[recurrence_points_start:recurrence_points_end],
+                                                                          recurrence_points_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           vertical_frequency_distribution,
+                                                                          vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.vertical_length_carryover[vertical_carryover_start:vertical_carryover_end],
+                                                                          vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           white_vertical_frequency_distribution,
+                                                                          white_vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.white_vertical_length_carryover[white_vertical_carryover_start:white_vertical_carryover_end],
+                                                                          white_vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           diagonal_frequency_distribution,
+                                                                          diagonal_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.diagonal_length_carryover[diagonal_carryover_start:diagonal_carryover_end],
+                                                                          diagonal_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))

--- a/pyrqa/rqa/fixed_radius/opencl/column_mat_bit_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_mat_bit_rec.py
@@ -108,7 +108,7 @@ class ColumnMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                  cl.mem_flags.READ_ONLY,
                                                  time_series_x.size * time_series_x.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          time_series_x_buffer,
                                                                          time_series_x,
                                                                          device_offset=0,
@@ -122,7 +122,7 @@ class ColumnMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                  cl.mem_flags.READ_ONLY,
                                                  time_series_y.size * time_series_y.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          time_series_y_buffer,
                                                                          time_series_y,
                                                                          device_offset=0,
@@ -132,7 +132,7 @@ class ColumnMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                 # Recurrence matrix
                 # matrix = self.get_bit_matrix(sub_matrix, self.data_type)
                 # matrix_buffer = cl.Buffer(context, cl.mem_flags.READ_WRITE, matrix.size * matrix.itemsize)
-                # transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
+                # transfer_to_device_events.append(cl.enqueue_copy(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
 
                 matrix_size, matrix_elements = self.get_bit_matrix_size(sub_matrix,
                                                                         self.data_type)
@@ -144,7 +144,7 @@ class ColumnMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                           cl.mem_flags.READ_WRITE,
                                           int(matrix_size))
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          matrix_buffer,
                                                                          matrix,
                                                                          device_offset=0,
@@ -160,7 +160,7 @@ class ColumnMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                      cl.mem_flags.READ_WRITE,
                                                      recurrence_points.size * recurrence_points.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          recurrence_points_buffer,
                                                                          recurrence_points,
                                                                          device_offset=0,
@@ -174,7 +174,7 @@ class ColumnMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    vertical_frequency_distribution.size * vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_frequency_distribution_buffer,
                                                                          vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -188,7 +188,7 @@ class ColumnMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                          cl.mem_flags.READ_WRITE,
                                                                          white_vertical_frequency_distribution.size * white_vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_frequency_distribution_buffer,
                                                                          white_vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -202,7 +202,7 @@ class ColumnMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    diagonal_frequency_distribution.size * diagonal_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_frequency_distribution_buffer,
                                                                          diagonal_frequency_distribution,
                                                                          device_offset=0,
@@ -218,7 +218,7 @@ class ColumnMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       vertical_carryover.size * vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_carryover_buffer,
                                                                          vertical_carryover,
                                                                          device_offset=0,
@@ -234,7 +234,7 @@ class ColumnMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                             cl.mem_flags.READ_WRITE,
                                                             white_vertical_carryover.size * white_vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_carryover_buffer,
                                                                          white_vertical_carryover,
                                                                          device_offset=0,
@@ -250,7 +250,7 @@ class ColumnMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       diagonal_carryover.size * diagonal_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_carryover_buffer,
                                                                          diagonal_carryover,
                                                                          device_offset=0,

--- a/pyrqa/rqa/fixed_radius/opencl/column_mat_bit_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_mat_bit_rec.py
@@ -12,7 +12,7 @@ import os
 import pyopencl as cl
 import threading
 
-import Queue
+import queue
 
 from ....abstract_classes import AbstractRunnable
 from ....opencl import OpenCL
@@ -412,7 +412,7 @@ class ColumnMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
 
                 self.threads_runtimes[device] += runtimes
 
-            except Queue.Empty:
+            except queue.Empty:
                 break
 
     def run_single_device(self):
@@ -441,7 +441,7 @@ class ColumnMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
         runtimes = Runtimes()
 
         if len(self.opencl.devices) == 0:
-            print 'No device specified!'
+            print('No device specified!')
             return 0
         elif len(self.opencl.devices) == 1:
             self.run_single_device()

--- a/pyrqa/rqa/fixed_radius/opencl/column_mat_byte_no_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_mat_byte_no_rec.py
@@ -339,51 +339,51 @@ class ColumnMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                 command_queue.finish()
 
                 # Read buffer
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          recurrence_points_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.recurrence_points[recurrence_points_start:recurrence_points_end],
+                                                                          recurrence_points_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           vertical_frequency_distribution,
+                                                                          vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.vertical_length_carryover[vertical_carryover_start:vertical_carryover_end],
+                                                                          vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           white_vertical_frequency_distribution,
+                                                                          white_vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.white_vertical_length_carryover[white_vertical_carryover_start:white_vertical_carryover_end],
+                                                                          white_vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           diagonal_frequency_distribution,
+                                                                          diagonal_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.diagonal_length_carryover[diagonal_carryover_start:diagonal_carryover_end],
+                                                                          diagonal_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))

--- a/pyrqa/rqa/fixed_radius/opencl/column_mat_byte_no_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_mat_byte_no_rec.py
@@ -106,7 +106,7 @@ class ColumnMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                  cl.mem_flags.READ_ONLY,
                                                  time_series_x.size * time_series_x.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          time_series_x_buffer,
                                                                          time_series_x,
                                                                          device_offset=0,
@@ -120,7 +120,7 @@ class ColumnMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                  cl.mem_flags.READ_ONLY,
                                                  time_series_y.size * time_series_y.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          time_series_y_buffer,
                                                                          time_series_y,
                                                                          device_offset=0,
@@ -131,7 +131,7 @@ class ColumnMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
 
                 # matrix = self.get_matrix(sub_matrix)
                 # matrix_buffer = cl.Buffer(context, cl.mem_flags.READ_WRITE, matrix.size * matrix.itemsize)
-                # transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
+                # transfer_to_device_events.append(cl.enqueue_copy(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
 
                 matrix = np.zeros(1, dtype=self.data_type)
 
@@ -139,7 +139,7 @@ class ColumnMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                           cl.mem_flags.READ_WRITE,
                                           int(self.get_recurrence_matrix_size(sub_matrix, self.data_type)))
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          matrix_buffer,
                                                                          matrix,
                                                                          device_offset=0,
@@ -155,7 +155,7 @@ class ColumnMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                      cl.mem_flags.READ_WRITE,
                                                      recurrence_points.size * recurrence_points.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          recurrence_points_buffer,
                                                                          recurrence_points,
                                                                          device_offset=0,
@@ -169,7 +169,7 @@ class ColumnMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    vertical_frequency_distribution.size * vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_frequency_distribution_buffer,
                                                                          vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -183,7 +183,7 @@ class ColumnMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                          cl.mem_flags.READ_WRITE,
                                                                          white_vertical_frequency_distribution.size * white_vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_frequency_distribution_buffer,
                                                                          white_vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -197,7 +197,7 @@ class ColumnMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    diagonal_frequency_distribution.size * diagonal_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_frequency_distribution_buffer,
                                                                          diagonal_frequency_distribution,
                                                                          device_offset=0,
@@ -213,7 +213,7 @@ class ColumnMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       vertical_carryover.size * vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_carryover_buffer,
                                                                          vertical_carryover,
                                                                          device_offset=0,
@@ -229,7 +229,7 @@ class ColumnMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                             cl.mem_flags.READ_WRITE,
                                                             white_vertical_carryover.size * white_vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_carryover_buffer,
                                                                          white_vertical_carryover,
                                                                          device_offset=0,
@@ -245,7 +245,7 @@ class ColumnMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       diagonal_carryover.size * diagonal_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_carryover_buffer,
                                                                          diagonal_carryover,
                                                                          device_offset=0,

--- a/pyrqa/rqa/fixed_radius/opencl/column_mat_byte_no_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_mat_byte_no_rec.py
@@ -12,7 +12,7 @@ import os
 import pyopencl as cl
 import threading
 
-import Queue
+import queue
 
 from ....abstract_classes import AbstractRunnable
 from ....opencl import OpenCL
@@ -405,7 +405,7 @@ class ColumnMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
 
                 self.threads_runtimes[device] += runtimes
 
-            except Queue.Empty:
+            except queue.Empty:
                 break
 
     def run_single_device(self):
@@ -434,7 +434,7 @@ class ColumnMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
         runtimes = Runtimes()
 
         if len(self.opencl.devices) == 0:
-            print 'No device specified!'
+            print('No device specified!')
             return 0
         elif len(self.opencl.devices) == 1:
             self.run_single_device()

--- a/pyrqa/rqa/fixed_radius/opencl/column_mat_byte_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_mat_byte_rec.py
@@ -319,51 +319,51 @@ class ColumnMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                 command_queue.finish()
 
                 # Read buffer
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          recurrence_points_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.recurrence_points[recurrence_points_start:recurrence_points_end],
+                                                                          recurrence_points_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           vertical_frequency_distribution,
+                                                                          vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.vertical_length_carryover[vertical_carryover_start:vertical_carryover_end],
+                                                                          vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           white_vertical_frequency_distribution,
+                                                                          white_vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.white_vertical_length_carryover[white_vertical_carryover_start:white_vertical_carryover_end],
+                                                                          white_vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           diagonal_frequency_distribution,
+                                                                          diagonal_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.diagonal_length_carryover[diagonal_carryover_start:diagonal_carryover_end],
+                                                                          diagonal_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))

--- a/pyrqa/rqa/fixed_radius/opencl/column_mat_byte_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_mat_byte_rec.py
@@ -12,7 +12,7 @@ import os
 import pyopencl as cl
 import threading
 
-import Queue
+import queue
 
 from ....abstract_classes import AbstractRunnable
 from ....opencl import OpenCL
@@ -385,7 +385,7 @@ class ColumnMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
 
                 self.threads_runtimes[device] += runtimes
 
-            except Queue.Empty:
+            except queue.Empty:
                 break
 
     def run_single_device(self):
@@ -414,7 +414,7 @@ class ColumnMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
         runtimes = Runtimes()
 
         if len(self.opencl.devices) == 0:
-            print 'No device specified!'
+            print('No device specified!')
             return 0
         elif len(self.opencl.devices) == 1:
             self.run_single_device()

--- a/pyrqa/rqa/fixed_radius/opencl/column_mat_byte_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_mat_byte_rec.py
@@ -105,7 +105,7 @@ class ColumnMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                  cl.mem_flags.READ_ONLY,
                                                  time_series_x.size * time_series_x.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          time_series_x_buffer,
                                                                          time_series_x,
                                                                          device_offset=0,
@@ -119,7 +119,7 @@ class ColumnMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                  cl.mem_flags.READ_ONLY,
                                                  time_series_y.size * time_series_y.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          time_series_y_buffer,
                                                                          time_series_y,
                                                                          device_offset=0,
@@ -130,7 +130,7 @@ class ColumnMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
 
                 # matrix = self.get_matrix(sub_matrix)
                 # matrix_buffer = cl.Buffer(context, cl.mem_flags.READ_WRITE, matrix.size * matrix.itemsize)
-                # transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
+                # transfer_to_device_events.append(cl.enqueue_copy(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
 
                 matrix = np.zeros(1, dtype=self.data_type)
 
@@ -138,7 +138,7 @@ class ColumnMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                           cl.mem_flags.READ_WRITE,
                                           int(self.get_recurrence_matrix_size(sub_matrix, self.data_type)))
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          matrix_buffer,
                                                                          matrix,
                                                                          device_offset=0,
@@ -154,7 +154,7 @@ class ColumnMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                      cl.mem_flags.READ_WRITE,
                                                      recurrence_points.size * recurrence_points.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          recurrence_points_buffer,
                                                                          recurrence_points,
                                                                          device_offset=0,
@@ -168,7 +168,7 @@ class ColumnMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    vertical_frequency_distribution.size * vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_frequency_distribution_buffer,
                                                                          vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -182,7 +182,7 @@ class ColumnMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                          cl.mem_flags.READ_WRITE,
                                                                          white_vertical_frequency_distribution.size * white_vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_frequency_distribution_buffer,
                                                                          white_vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -196,7 +196,7 @@ class ColumnMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    diagonal_frequency_distribution.size * diagonal_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_frequency_distribution_buffer,
                                                                          diagonal_frequency_distribution,
                                                                          device_offset=0,
@@ -212,7 +212,7 @@ class ColumnMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       vertical_carryover.size * vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_carryover_buffer,
                                                                          vertical_carryover,
                                                                          device_offset=0,
@@ -228,7 +228,7 @@ class ColumnMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                             cl.mem_flags.READ_WRITE,
                                                             white_vertical_carryover.size * white_vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_carryover_buffer,
                                                                          white_vertical_carryover,
                                                                          device_offset=0,
@@ -244,7 +244,7 @@ class ColumnMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       diagonal_carryover.size * diagonal_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_carryover_buffer,
                                                                          diagonal_carryover,
                                                                          device_offset=0,

--- a/pyrqa/rqa/fixed_radius/opencl/column_no_mat.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_no_mat.py
@@ -301,51 +301,51 @@ class ColumnNoMat(RQASubMatricesCarryover, AbstractRunnable):
                 command_queue.finish()
 
                 # Read buffer
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          recurrence_points_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.recurrence_points[recurrence_points_start:recurrence_points_end],
+                                                                          recurrence_points_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           vertical_frequency_distribution,
+                                                                          vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.vertical_length_carryover[vertical_carryover_start:vertical_carryover_end],
+                                                                          vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           white_vertical_frequency_distribution,
+                                                                          white_vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.white_vertical_length_carryover[white_vertical_carryover_start:white_vertical_carryover_end],
+                                                                          white_vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           diagonal_frequency_distribution,
+                                                                          diagonal_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.diagonal_length_carryover[diagonal_carryover_start:diagonal_carryover_end],
+                                                                          diagonal_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))

--- a/pyrqa/rqa/fixed_radius/opencl/column_no_mat.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_no_mat.py
@@ -12,7 +12,7 @@ import os
 import pyopencl as cl
 import threading
 
-import Queue
+import queue
 
 from ....abstract_classes import AbstractRunnable
 from ....opencl import OpenCL
@@ -367,7 +367,7 @@ class ColumnNoMat(RQASubMatricesCarryover, AbstractRunnable):
 
                 self.threads_runtimes[device] += runtimes
 
-            except Queue.Empty:
+            except queue.Empty:
                 break
 
     def run_single_device(self):
@@ -396,7 +396,7 @@ class ColumnNoMat(RQASubMatricesCarryover, AbstractRunnable):
         runtimes = Runtimes()
 
         if len(self.opencl.devices) == 0:
-            print 'No device specified!'
+            print('No device specified!')
             return 0
         elif len(self.opencl.devices) == 1:
             self.run_single_device()

--- a/pyrqa/rqa/fixed_radius/opencl/column_no_mat.py
+++ b/pyrqa/rqa/fixed_radius/opencl/column_no_mat.py
@@ -102,7 +102,7 @@ class ColumnNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                  cl.mem_flags.READ_ONLY,
                                                  time_series_x.size * time_series_x.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          time_series_x_buffer,
                                                                          time_series_x,
                                                                          device_offset=0,
@@ -116,7 +116,7 @@ class ColumnNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                  cl.mem_flags.READ_ONLY,
                                                  time_series_y.size * time_series_y.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          time_series_y_buffer,
                                                                          time_series_y,
                                                                          device_offset=0,
@@ -132,7 +132,7 @@ class ColumnNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                      cl.mem_flags.READ_WRITE,
                                                      recurrence_points.size * recurrence_points.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          recurrence_points_buffer,
                                                                          recurrence_points,
                                                                          device_offset=0,
@@ -146,7 +146,7 @@ class ColumnNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    vertical_frequency_distribution.size * vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_frequency_distribution_buffer,
                                                                          vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -160,7 +160,7 @@ class ColumnNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                                          cl.mem_flags.READ_WRITE,
                                                                          vertical_frequency_distribution.size * vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_frequency_distribution_buffer,
                                                                          white_vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -174,7 +174,7 @@ class ColumnNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    diagonal_frequency_distribution.size * diagonal_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_frequency_distribution_buffer,
                                                                          diagonal_frequency_distribution,
                                                                          device_offset=0,
@@ -190,7 +190,7 @@ class ColumnNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       vertical_carryover.size * vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_carryover_buffer,
                                                                          vertical_carryover,
                                                                          device_offset=0,
@@ -206,7 +206,7 @@ class ColumnNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                             cl.mem_flags.READ_WRITE,
                                                             white_vertical_carryover.size * white_vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_carryover_buffer,
                                                                          white_vertical_carryover,
                                                                          device_offset=0,
@@ -222,7 +222,7 @@ class ColumnNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       diagonal_carryover.size * diagonal_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_carryover_buffer,
                                                                          diagonal_carryover,
                                                                          device_offset=0,

--- a/pyrqa/rqa/fixed_radius/opencl/row_mat_bit_no_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_mat_bit_no_rec.py
@@ -109,7 +109,7 @@ class RowMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                              cl.mem_flags.READ_ONLY,
                                              vectors_x.size * vectors_x.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vectors_x_buffer,
                                                                          vectors_x,
                                                                          device_offset=0,
@@ -123,7 +123,7 @@ class RowMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                              cl.mem_flags.READ_ONLY,
                                              vectors_y.size * vectors_y.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vectors_y_buffer,
                                                                          vectors_y,
                                                                          device_offset=0,
@@ -133,7 +133,7 @@ class RowMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                 # Recurrence matrix
                 # matrix = self.get_bit_matrix(sub_matrix, self.data_type)
                 # matrix_buffer = cl.Buffer(context, cl.mem_flags.READ_WRITE, matrix.size * matrix.itemsize)
-                # transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
+                # transfer_to_device_events.append(cl.enqueue_copy(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
 
                 matrix_size, matrix_elements = self.get_bit_matrix_size(sub_matrix,
                                                                         self.data_type)
@@ -145,7 +145,7 @@ class RowMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                           cl.mem_flags.READ_WRITE,
                                           int(matrix_size))
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          matrix_buffer,
                                                                          matrix,
                                                                          device_offset=0,
@@ -161,7 +161,7 @@ class RowMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                      cl.mem_flags.READ_WRITE,
                                                      recurrence_points.size * recurrence_points.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          recurrence_points_buffer,
                                                                          recurrence_points,
                                                                          device_offset=0,
@@ -175,7 +175,7 @@ class RowMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    vertical_frequency_distribution.size * vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_frequency_distribution_buffer,
                                                                          vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -189,7 +189,7 @@ class RowMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                          cl.mem_flags.READ_WRITE,
                                                                          white_vertical_frequency_distribution.size * white_vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_frequency_distribution_buffer,
                                                                          white_vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -202,7 +202,7 @@ class RowMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    diagonal_frequency_distribution.size * diagonal_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_frequency_distribution_buffer,
                                                                          diagonal_frequency_distribution,
                                                                          device_offset=0,
@@ -218,7 +218,7 @@ class RowMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       vertical_carryover.size * vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_carryover_buffer,
                                                                          vertical_carryover,
                                                                          device_offset=0,
@@ -234,7 +234,7 @@ class RowMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                             cl.mem_flags.READ_WRITE,
                                                             white_vertical_carryover.size * white_vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_carryover_buffer,
                                                                          white_vertical_carryover,
                                                                          device_offset=0,
@@ -250,7 +250,7 @@ class RowMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       diagonal_carryover.size * diagonal_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_carryover_buffer,
                                                                          diagonal_carryover,
                                                                          device_offset=0,

--- a/pyrqa/rqa/fixed_radius/opencl/row_mat_bit_no_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_mat_bit_no_rec.py
@@ -366,51 +366,51 @@ class RowMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
                 command_queue.finish()
 
                 # Read buffer
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          recurrence_points_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.recurrence_points[recurrence_points_start:recurrence_points_end],
+                                                                          recurrence_points_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           vertical_frequency_distribution,
+                                                                          vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.vertical_length_carryover[vertical_carryover_start:vertical_carryover_end],
+                                                                          vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           white_vertical_frequency_distribution,
+                                                                          white_vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.white_vertical_length_carryover[white_vertical_carryover_start:white_vertical_carryover_end],
+                                                                          white_vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           diagonal_frequency_distribution,
+                                                                          diagonal_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.diagonal_length_carryover[diagonal_carryover_start:diagonal_carryover_end],
+                                                                          diagonal_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))

--- a/pyrqa/rqa/fixed_radius/opencl/row_mat_bit_no_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_mat_bit_no_rec.py
@@ -12,7 +12,7 @@ import os
 import pyopencl as cl
 import threading
 
-import Queue
+import queue
 
 from ....abstract_classes import AbstractRunnable
 from ....opencl import OpenCL
@@ -432,7 +432,7 @@ class RowMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
 
                 self.threads_runtimes[device] += runtimes
 
-            except Queue.Empty:
+            except queue.Empty:
                 break
 
     def run_single_device(self):
@@ -461,7 +461,7 @@ class RowMatBitNoRec(RQASubMatricesCarryover, AbstractRunnable):
         runtimes = Runtimes()
 
         if len(self.opencl.devices) == 0:
-            print 'No device specified!'
+            print('No device specified!')
             return 0
         elif len(self.opencl.devices) == 1:
             self.run_single_device()

--- a/pyrqa/rqa/fixed_radius/opencl/row_mat_bit_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_mat_bit_rec.py
@@ -12,7 +12,7 @@ import os
 import pyopencl as cl
 import threading
 
-import Queue
+import queue
 
 from ....abstract_classes import AbstractRunnable
 from ....opencl import OpenCL
@@ -412,7 +412,7 @@ class RowMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
 
                 self.threads_runtimes[device] += runtimes
 
-            except Queue.Empty:
+            except queue.Empty:
                 break
 
     def run_single_device(self):
@@ -441,7 +441,7 @@ class RowMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
         runtimes = Runtimes()
 
         if len(self.opencl.devices) == 0:
-            print 'No device specified!'
+            print('No device specified!')
             return 0
         elif len(self.opencl.devices) == 1:
             self.run_single_device()

--- a/pyrqa/rqa/fixed_radius/opencl/row_mat_bit_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_mat_bit_rec.py
@@ -346,51 +346,51 @@ class RowMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                 command_queue.finish()
 
                 # Read buffer
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          recurrence_points_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.recurrence_points[recurrence_points_start:recurrence_points_end],
+                                                                          recurrence_points_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           vertical_frequency_distribution,
+                                                                          vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.vertical_length_carryover[vertical_carryover_start:vertical_carryover_end],
+                                                                          vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           white_vertical_frequency_distribution,
+                                                                          white_vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.white_vertical_length_carryover[white_vertical_carryover_start:white_vertical_carryover_end],
+                                                                          white_vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           diagonal_frequency_distribution,
+                                                                          diagonal_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.diagonal_length_carryover[diagonal_carryover_start:diagonal_carryover_end],
+                                                                          diagonal_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))

--- a/pyrqa/rqa/fixed_radius/opencl/row_mat_bit_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_mat_bit_rec.py
@@ -108,7 +108,7 @@ class RowMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                              cl.mem_flags.READ_ONLY,
                                              vectors_x.size * vectors_x.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vectors_x_buffer,
                                                                          vectors_x,
                                                                          device_offset=0,
@@ -122,7 +122,7 @@ class RowMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                              cl.mem_flags.READ_ONLY,
                                              vectors_y.size * vectors_y.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vectors_y_buffer,
                                                                          vectors_y,
                                                                          device_offset=0,
@@ -132,7 +132,7 @@ class RowMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                 # Recurrence matrix
                 # matrix = self.get_bit_matrix(sub_matrix, self.data_type)
                 # matrix_buffer = cl.Buffer(context, cl.mem_flags.READ_WRITE, matrix.size * matrix.itemsize)
-                # transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
+                # transfer_to_device_events.append(cl.enqueue_copy(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
 
                 matrix_size, matrix_elements = self.get_bit_matrix_size(sub_matrix,
                                                                         self.data_type)
@@ -144,7 +144,7 @@ class RowMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                           cl.mem_flags.READ_WRITE,
                                           int(matrix_size))
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          matrix_buffer,
                                                                          matrix,
                                                                          device_offset=0,
@@ -160,7 +160,7 @@ class RowMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                      cl.mem_flags.READ_WRITE,
                                                      recurrence_points.size * recurrence_points.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          recurrence_points_buffer,
                                                                          recurrence_points,
                                                                          device_offset=0,
@@ -174,7 +174,7 @@ class RowMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    vertical_frequency_distribution.size * vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_frequency_distribution_buffer,
                                                                          vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -188,7 +188,7 @@ class RowMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                          cl.mem_flags.READ_WRITE,
                                                                          white_vertical_frequency_distribution.size * white_vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_frequency_distribution_buffer,
                                                                          white_vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -202,7 +202,7 @@ class RowMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    diagonal_frequency_distribution.size * diagonal_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_frequency_distribution_buffer,
                                                                          diagonal_frequency_distribution,
                                                                          device_offset=0,
@@ -218,7 +218,7 @@ class RowMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       vertical_carryover.size * vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_carryover_buffer,
                                                                          vertical_carryover,
                                                                          device_offset=0,
@@ -234,7 +234,7 @@ class RowMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                             cl.mem_flags.READ_WRITE,
                                                             white_vertical_carryover.size * white_vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_carryover_buffer,
                                                                          white_vertical_carryover,
                                                                          device_offset=0,
@@ -250,7 +250,7 @@ class RowMatBitRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       diagonal_carryover.size * diagonal_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_carryover_buffer,
                                                                          diagonal_carryover,
                                                                          device_offset=0,

--- a/pyrqa/rqa/fixed_radius/opencl/row_mat_byte_no_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_mat_byte_no_rec.py
@@ -341,51 +341,51 @@ class RowMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                 command_queue.finish()
 
                 # Read buffer
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          recurrence_points_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.recurrence_points[recurrence_points_start:recurrence_points_end],
+                                                                          recurrence_points_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           vertical_frequency_distribution,
+                                                                          vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.vertical_length_carryover[vertical_carryover_start:vertical_carryover_end],
+                                                                          vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           white_vertical_frequency_distribution,
+                                                                          white_vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.white_vertical_length_carryover[white_vertical_carryover_start:white_vertical_carryover_end],
+                                                                          white_vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           diagonal_frequency_distribution,
+                                                                          diagonal_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.diagonal_length_carryover[diagonal_carryover_start:diagonal_carryover_end],
+                                                                          diagonal_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))

--- a/pyrqa/rqa/fixed_radius/opencl/row_mat_byte_no_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_mat_byte_no_rec.py
@@ -106,7 +106,7 @@ class RowMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                              cl.mem_flags.READ_ONLY,
                                              vectors_x.size * vectors_x.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vectors_x_buffer,
                                                                          vectors_x,
                                                                          device_offset=0,
@@ -120,7 +120,7 @@ class RowMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                              cl.mem_flags.READ_ONLY,
                                              vectors_y.size * vectors_y.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vectors_y_buffer,
                                                                          vectors_y,
                                                                          device_offset=0,
@@ -131,7 +131,7 @@ class RowMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
 
                 # matrix = self.get_matrix(sub_matrix)
                 # matrix_buffer = cl.Buffer(context, cl.mem_flags.READ_WRITE, matrix.size * matrix.itemsize)
-                # transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
+                # transfer_to_device_events.append(cl.enqueue_copy(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
 
                 matrix = np.zeros(1,
                                   dtype=self.data_type)
@@ -140,7 +140,7 @@ class RowMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                           cl.mem_flags.READ_WRITE,
                                           int(self.get_recurrence_matrix_size(sub_matrix, self.data_type)))
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          matrix_buffer, matrix,
                                                                          device_offset=0,
                                                                          wait_for=None,
@@ -155,7 +155,7 @@ class RowMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                      cl.mem_flags.READ_WRITE,
                                                      recurrence_points.size * recurrence_points.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          recurrence_points_buffer,
                                                                          recurrence_points,
                                                                          device_offset=0,
@@ -169,7 +169,7 @@ class RowMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    vertical_frequency_distribution.size * vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_frequency_distribution_buffer,
                                                                          vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -182,7 +182,7 @@ class RowMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                          cl.mem_flags.READ_WRITE,
                                                                          white_vertical_frequency_distribution.size * white_vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_frequency_distribution_buffer,
                                                                          white_vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -196,7 +196,7 @@ class RowMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    diagonal_frequency_distribution.size * diagonal_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_frequency_distribution_buffer,
                                                                          diagonal_frequency_distribution,
                                                                          device_offset=0,
@@ -212,7 +212,7 @@ class RowMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       vertical_carryover.size * vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_carryover_buffer,
                                                                          vertical_carryover,
                                                                          device_offset=0,
@@ -228,7 +228,7 @@ class RowMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                             cl.mem_flags.READ_WRITE,
                                                             white_vertical_carryover.size * white_vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_carryover_buffer,
                                                                          white_vertical_carryover,
                                                                          device_offset=0,
@@ -244,7 +244,7 @@ class RowMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       diagonal_carryover.size * diagonal_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_carryover_buffer,
                                                                          diagonal_carryover,
                                                                          device_offset=0,

--- a/pyrqa/rqa/fixed_radius/opencl/row_mat_byte_no_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_mat_byte_no_rec.py
@@ -12,7 +12,7 @@ import os
 import pyopencl as cl
 import threading
 
-import Queue
+import queue
 
 from ....abstract_classes import AbstractRunnable
 from ....opencl import OpenCL
@@ -407,7 +407,7 @@ class RowMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
 
                 self.threads_runtimes[device] += runtimes
 
-            except Queue.Empty:
+            except queue.Empty:
                 break
 
     def run_single_device(self):
@@ -436,7 +436,7 @@ class RowMatByteNoRec(RQASubMatricesCarryover, AbstractRunnable):
         runtimes = Runtimes()
 
         if len(self.opencl.devices) == 0:
-            print 'No device specified!'
+            print('No device specified!')
             return 0
         elif len(self.opencl.devices) == 1:
             self.run_single_device()

--- a/pyrqa/rqa/fixed_radius/opencl/row_mat_byte_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_mat_byte_rec.py
@@ -105,7 +105,7 @@ class RowMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                              cl.mem_flags.READ_ONLY,
                                              vectors_x.size * vectors_x.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vectors_x_buffer,
                                                                          vectors_x,
                                                                          device_offset=0,
@@ -119,7 +119,7 @@ class RowMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                              cl.mem_flags.READ_ONLY,
                                              vectors_y.size * vectors_y.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vectors_y_buffer,
                                                                          vectors_y,
                                                                          device_offset=0,
@@ -130,7 +130,7 @@ class RowMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
 
                 # matrix = self.get_matrix(sub_matrix)
                 # matrix_buffer = cl.Buffer(context, cl.mem_flags.READ_WRITE, matrix.size * matrix.itemsize)
-                # transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
+                # transfer_to_device_events.append(cl.enqueue_copy(command_queue, matrix_buffer, matrix, device_offset=0, wait_for=None, is_blocking=False))
 
                 matrix = np.zeros(1,
                                   dtype=self.data_type)
@@ -139,7 +139,7 @@ class RowMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                           cl.mem_flags.READ_WRITE,
                                           int(self.get_recurrence_matrix_size(sub_matrix, self.data_type)))
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          matrix_buffer,
                                                                          matrix,
                                                                          device_offset=0,
@@ -155,7 +155,7 @@ class RowMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                      cl.mem_flags.READ_WRITE,
                                                      recurrence_points.size * recurrence_points.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          recurrence_points_buffer,
                                                                          recurrence_points,
                                                                          device_offset=0,
@@ -169,7 +169,7 @@ class RowMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    vertical_frequency_distribution.size * vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_frequency_distribution_buffer,
                                                                          vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -183,7 +183,7 @@ class RowMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                          cl.mem_flags.READ_WRITE,
                                                                          white_vertical_frequency_distribution.size * white_vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_frequency_distribution_buffer,
                                                                          white_vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -197,7 +197,7 @@ class RowMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    diagonal_frequency_distribution.size * diagonal_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_frequency_distribution_buffer,
                                                                          diagonal_frequency_distribution,
                                                                          device_offset=0,
@@ -213,7 +213,7 @@ class RowMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       vertical_carryover.size * vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_carryover_buffer,
                                                                          vertical_carryover,
                                                                          device_offset=0,
@@ -229,7 +229,7 @@ class RowMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                             cl.mem_flags.READ_WRITE,
                                                             white_vertical_carryover.size * white_vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_carryover_buffer,
                                                                          white_vertical_carryover,
                                                                          device_offset=0,
@@ -245,7 +245,7 @@ class RowMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       diagonal_carryover.size * diagonal_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_carryover_buffer,
                                                                          diagonal_carryover,
                                                                          device_offset=0,

--- a/pyrqa/rqa/fixed_radius/opencl/row_mat_byte_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_mat_byte_rec.py
@@ -323,51 +323,51 @@ class RowMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
                 command_queue.finish()
 
                 # Read buffer
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          recurrence_points_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.recurrence_points[recurrence_points_start:recurrence_points_end],
+                                                                          recurrence_points_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           vertical_frequency_distribution,
+                                                                          vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.vertical_length_carryover[vertical_carryover_start:vertical_carryover_end],
+                                                                          vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           white_vertical_frequency_distribution,
+                                                                          white_vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.white_vertical_length_carryover[white_vertical_carryover_start:white_vertical_carryover_end],
+                                                                          white_vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           diagonal_frequency_distribution,
+                                                                          diagonal_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.diagonal_length_carryover[diagonal_carryover_start:diagonal_carryover_end],
+                                                                          diagonal_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))

--- a/pyrqa/rqa/fixed_radius/opencl/row_mat_byte_rec.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_mat_byte_rec.py
@@ -12,7 +12,7 @@ import os
 import pyopencl as cl
 import threading
 
-import Queue
+import queue
 
 from ....abstract_classes import AbstractRunnable
 from ....opencl import OpenCL
@@ -389,7 +389,7 @@ class RowMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
 
                 self.threads_runtimes[device] += runtimes
 
-            except Queue.Empty:
+            except queue.Empty:
                 break
 
     def run_single_device(self):
@@ -418,7 +418,7 @@ class RowMatByteRec(RQASubMatricesCarryover, AbstractRunnable):
         runtimes = Runtimes()
 
         if len(self.opencl.devices) == 0:
-            print 'No device specified!'
+            print('No device specified!')
             return 0
         elif len(self.opencl.devices) == 1:
             self.run_single_device()

--- a/pyrqa/rqa/fixed_radius/opencl/row_no_mat.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_no_mat.py
@@ -12,7 +12,7 @@ import os
 import pyopencl as cl
 import threading
 
-import Queue
+import queue
 
 from ....abstract_classes import AbstractRunnable
 from ....opencl import OpenCL
@@ -369,7 +369,7 @@ class RowNoMat(RQASubMatricesCarryover, AbstractRunnable):
 
                 self.threads_runtimes[device] += runtimes
 
-            except Queue.Empty:
+            except queue.Empty:
                 break
 
     def run_single_device(self):
@@ -398,7 +398,7 @@ class RowNoMat(RQASubMatricesCarryover, AbstractRunnable):
         runtimes = Runtimes()
 
         if len(self.opencl.devices) == 0:
-            print 'No device specified!'
+            print('No device specified!')
             return 0
         elif len(self.opencl.devices) == 1:
             self.run_single_device()

--- a/pyrqa/rqa/fixed_radius/opencl/row_no_mat.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_no_mat.py
@@ -102,7 +102,7 @@ class RowNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                              cl.mem_flags.READ_ONLY,
                                              vectors_x.size * vectors_x.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vectors_x_buffer,
                                                                          vectors_x,
                                                                          device_offset=0,
@@ -116,7 +116,7 @@ class RowNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                              cl.mem_flags.READ_ONLY,
                                              vectors_y.size * vectors_y.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vectors_y_buffer,
                                                                          vectors_y,
                                                                          device_offset=0,
@@ -132,7 +132,7 @@ class RowNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                      cl.mem_flags.READ_WRITE,
                                                      recurrence_points.size * recurrence_points.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          recurrence_points_buffer,
                                                                          recurrence_points,
                                                                          device_offset=0,
@@ -146,7 +146,7 @@ class RowNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    vertical_frequency_distribution.size * vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_frequency_distribution_buffer,
                                                                          vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -160,7 +160,7 @@ class RowNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                                          cl.mem_flags.READ_WRITE,
                                                                          white_vertical_frequency_distribution.size * white_vertical_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_frequency_distribution_buffer,
                                                                          white_vertical_frequency_distribution,
                                                                          device_offset=0,
@@ -174,7 +174,7 @@ class RowNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                                    cl.mem_flags.READ_WRITE,
                                                                    diagonal_frequency_distribution.size * diagonal_frequency_distribution.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_frequency_distribution_buffer,
                                                                          diagonal_frequency_distribution,
                                                                          device_offset=0,
@@ -190,7 +190,7 @@ class RowNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       vertical_carryover.size * vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          vertical_carryover_buffer,
                                                                          vertical_carryover,
                                                                          device_offset=0,
@@ -206,7 +206,7 @@ class RowNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                             cl.mem_flags.READ_WRITE,
                                                             white_vertical_carryover.size * white_vertical_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          white_vertical_carryover_buffer,
                                                                          white_vertical_carryover,
                                                                          device_offset=0,
@@ -222,7 +222,7 @@ class RowNoMat(RQASubMatricesCarryover, AbstractRunnable):
                                                       cl.mem_flags.READ_WRITE,
                                                       diagonal_carryover.size * diagonal_carryover.itemsize)
 
-                transfer_to_device_events.append(cl.enqueue_write_buffer(command_queue,
+                transfer_to_device_events.append(cl.enqueue_copy(command_queue,
                                                                          diagonal_carryover_buffer,
                                                                          diagonal_carryover,
                                                                          device_offset=0,

--- a/pyrqa/rqa/fixed_radius/opencl/row_no_mat.py
+++ b/pyrqa/rqa/fixed_radius/opencl/row_no_mat.py
@@ -303,51 +303,51 @@ class RowNoMat(RQASubMatricesCarryover, AbstractRunnable):
                 command_queue.finish()
 
                 # Read buffer
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          recurrence_points_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.recurrence_points[recurrence_points_start:recurrence_points_end],
+                                                                          recurrence_points_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           vertical_frequency_distribution,
+                                                                          vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.vertical_length_carryover[vertical_carryover_start:vertical_carryover_end],
+                                                                          vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           white_vertical_frequency_distribution,
+                                                                          white_vertical_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          white_vertical_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.white_vertical_length_carryover[white_vertical_carryover_start:white_vertical_carryover_end],
+                                                                          white_vertical_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_frequency_distribution_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           diagonal_frequency_distribution,
+                                                                          diagonal_frequency_distribution_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))
 
-                transfer_from_device_events.append(cl.enqueue_read_buffer(command_queue,
-                                                                          diagonal_carryover_buffer,
+                transfer_from_device_events.append(cl.enqueue_copy(command_queue,
                                                                           self.diagonal_length_carryover[diagonal_carryover_start:diagonal_carryover_end],
+                                                                          diagonal_carryover_buffer,
                                                                           device_offset=0,
                                                                           wait_for=None,
                                                                           is_blocking=False))

--- a/pyrqa/settings.py
+++ b/pyrqa/settings.py
@@ -11,10 +11,10 @@ import inspect
 import numpy as np
 import os
 
-from config_parser import ConfigurationParser
-from exceptions import NoOpenCLKernelsFoundException
-from metric import EuclideanMetric
-from neighbourhood import FixedRadius, RadiusCorridor
+from .config_parser import ConfigurationParser
+from .exceptions import NoOpenCLKernelsFoundException
+from .metric import EuclideanMetric
+from .neighbourhood import FixedRadius, RadiusCorridor
 
 
 class Settings(object):

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     author_email="tobias.rawald@gfz-potsdam.de",
     keywords=["time series analysis", "recurrence quantification analysis", "RQA", "recurrence plot"],
     classifiers=[
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.10",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Update log:
- Run `2to3` to migrate most of the code into python3.
- Change some `pyopencl` commands to use `pyopencl 2024.3`.

All tests are passed.